### PR TITLE
Update readme.markdown

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -255,9 +255,8 @@ to run the command without installing it globally.
 
 # platform support
 
-This module works on node v8, but only v10 and above are officially
-supported, as Node v8 reached its LTS end of life 2020-01-01, which is in
-the past, as of this writing.
+Only v10 and above are officially supported, as Node v8 reached its LTS
+end of life 2020-01-01, which is in the past, as of this writing.
 
 # license
 


### PR DESCRIPTION
Change platform support based on https://github.com/isaacs/node-mkdirp/issues/2

Related error message:

```
error mkdirp@1.0.4: The engine "node" is incompatible with this module. Expected version ">=10". Got "8.17.0"
error Found incompatible module.
```

So, clearly, this module DOES NOT work on node v8.