### PR TITLE
fix backward compability for cjs exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,9 +11,8 @@
     "recursive",
     "native"
   ],
-  "main": "./dist/cjs/index.js",
+  "main": "./dist/cjs/index-cjs.js",
   "module": "./dist/mjs/index.js",
-  "types": "./dist/cjs/index.d.ts",
   "bin": "./dist/cjs/bin.js",
   "exports": {
     ".": {
@@ -22,8 +21,8 @@
         "types": "./dist/mjs/index.d.ts"
       },
       "require": {
-        "default": "./dist/cjs/index.js",
-        "types": "./dist/cjs/index.d.ts"
+        "default": "./dist/cjs/index-cjs.js",
+        "types": "./dist/cjs/index-cjs.d.ts"
       }
     }
   },

--- a/src/index-cjs.ts
+++ b/src/index-cjs.ts
@@ -1,0 +1,3 @@
+import mkdirp from './index.js';
+
+export = mkdirp;

--- a/tsconfig-cjs.json
+++ b/tsconfig-cjs.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig-base.json",
   "compilerOptions": {
     "module": "commonjs",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "moduleResolution": "Node"
   }
 }

--- a/tsconfig-esm.json
+++ b/tsconfig-esm.json
@@ -1,5 +1,6 @@
 {
   "extends": "./tsconfig-base.json",
+  "exclude": ["./test", "./tap-snapshots", "src/index-cjs.ts"],
   "compilerOptions": {
     "module": "esnext",
     "outDir": "dist/mjs"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,0 @@
-{
-  "extends": "./tsconfig-base.json",
-  "compilerOptions": {
-    "module": "commonjs",
-    "outDir": "dist/cjs"
-  }
-}


### PR DESCRIPTION
Fixes https://github.com/isaacs/node-mkdirp/issues/40

Some files were missing from the repos, so I had to put place holders for `tsconfig.json`, `tsconfig-esm.json`, `tsconfig-cjs.json` and `fixup.sh`. 

When loading from a cjs import, mkdir will be available directly instead of being wrapped in a es6 module.